### PR TITLE
Fix start bench pins NPEs when start is not overridden

### DIFF
--- a/RandoMapCore/BenchwarpInterop.cs
+++ b/RandoMapCore/BenchwarpInterop.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using Benchwarp;
 using InControl;
+using ItemChanger;
 using MapChanger;
 using Modding;
 using UnityEngine;
@@ -42,7 +43,14 @@ internal class BenchwarpInterop : HookModule
             }
         }
 
-        StartKey = new(ItemChanger.Internal.Ref.Settings.Start.SceneName, "ITEMCHANGER_RESPAWN_MARKER");
+        if (ItemChanger.Internal.Ref.Settings.Start != null)
+        {
+            StartKey = new(ItemChanger.Internal.Ref.Settings.Start.SceneName, "ITEMCHANGER_RESPAWN_MARKER");
+        }
+        else
+        {
+            StartKey = new(SceneNames.Tutorial_01, "Death Respawn Marker");
+        }
         benchNames.Add(StartKey, BENCH_WARP_START);
 
         BenchNames = new(benchNames);

--- a/RandoMapCore/Pins/Defs/StartBenchPinDef.cs
+++ b/RandoMapCore/Pins/Defs/StartBenchPinDef.cs
@@ -1,3 +1,4 @@
+using ItemChanger;
 using MapChanger.Defs;
 
 namespace RandoMapCore.Pins;
@@ -5,7 +6,7 @@ namespace RandoMapCore.Pins;
 internal sealed class StartBenchPinDef : BenchPinDef
 {
     internal StartBenchPinDef()
-        : base(BenchwarpInterop.BENCH_WARP_START, ItemChanger.Internal.Ref.Settings.Start.SceneName) { }
+        : base(BenchwarpInterop.BENCH_WARP_START, ItemChanger.Internal.Ref.Settings.Start?.SceneName ?? SceneNames.Tutorial_01) { }
 
     private protected override MapRoomPosition GetBenchMapPosition()
     {
@@ -13,7 +14,7 @@ internal sealed class StartBenchPinDef : BenchPinDef
 
         if (MapChanger.Finder.IsMappedScene(SceneName))
         {
-            return new WorldMapPosition((SceneName, start.X, start.Y));
+            return new WorldMapPosition((SceneName, start?.X ?? 0, start?.Y ?? 0));
         }
         else
         {


### PR DESCRIPTION
This corrects NPE issues when start is not overridden in itemchanger. I didn't put any particular effort into making the pin position pretty so it is currently offset, but if you wanted to set it to match the normal KP warp position you certainly could