### PR TITLE
Improvements to formatting for info panel

### DIFF
--- a/RandoMapCore/Pins/Defs/BenchInfo.cs
+++ b/RandoMapCore/Pins/Defs/BenchInfo.cs
@@ -1,3 +1,4 @@
+using MagicUI.Elements;
 using MapChanger;
 using RandoMapCore.Input;
 
@@ -14,7 +15,7 @@ internal class BenchInfo(string name)
         IsActiveBench = RandoMapCoreMod.GS.ShowBenchwarpPins && IsVisitedBench;
     }
 
-    internal string GetBenchwarpText()
+    internal RunCollection GetBenchwarpText()
     {
         if (!IsActiveBench)
         {
@@ -22,6 +23,10 @@ internal class BenchInfo(string name)
         }
 
         var bindingsText = BenchwarpInput.Instance.GetBindingsText();
-        return $"{"Hold".L()} {bindingsText} {"to benchwarp".L()}.";
+        return [
+            new Run($"{"Hold".L()} "),
+            new Run(bindingsText),
+            new Run($"{"to benchwarp".L()}.")
+        ];
     }
 }

--- a/RandoMapCore/Pins/Defs/BenchPinDef.cs
+++ b/RandoMapCore/Pins/Defs/BenchPinDef.cs
@@ -1,3 +1,4 @@
+using MagicUI.Elements;
 using MapChanger;
 using MapChanger.Defs;
 using RandoMapCore.Settings;
@@ -89,8 +90,11 @@ internal class BenchPinDef : PinDef
         return base.GetZPriority();
     }
 
-    private protected override string GetStatusText()
+    private protected override RunCollection GetStatusText()
     {
-        return $"{"Status".L()}: {(Bench.IsVisitedBench ? "Can warp" : "Cannot warp").L()}";
+        return [
+            new Run($"{"Status".L()}: "),
+            new Run((Bench.IsVisitedBench ? "Can warp" : "Cannot warp").L())
+        ];
     }
 }

--- a/RandoMapCore/Pins/Defs/HintInfo.cs
+++ b/RandoMapCore/Pins/Defs/HintInfo.cs
@@ -1,3 +1,4 @@
+using MagicUI.Elements;
 using MapChanger;
 using RandoMapCore.Input;
 using RandoMapCore.UI;
@@ -36,7 +37,7 @@ public class HintInfo
         _text = string.Join("\n", _logicDefs.Where(ld => ld.CanGet(_pm)).Select(ld => ld.Name.L()));
     }
 
-    internal string GetHintText()
+    internal RunCollection GetHintText()
     {
         if (_text == string.Empty)
         {
@@ -45,10 +46,14 @@ public class HintInfo
 
         if (PinSelectionPanel.Instance?.ShowHint ?? false)
         {
-            return _text;
+            return [new Run(_text)];
         }
 
         var bindingsText = LocationHintInput.Instance.GetBindingsText();
-        return $"{"Press".L()} {bindingsText} {"to reveal location hint".L()}.";
+        return [
+            new Run($"{"Press".L()} "),
+            new Run(bindingsText),
+            new Run($" {"to reveal location hint".L()}."),
+        ];
     }
 }

--- a/RandoMapCore/Pins/Defs/ICLogicPinDef.cs
+++ b/RandoMapCore/Pins/Defs/ICLogicPinDef.cs
@@ -1,4 +1,5 @@
 using ItemChanger;
+using MagicUI.Elements;
 using MapChanger;
 using RandoMapCore.Settings;
 using RandomizerCore.Logic;
@@ -98,13 +99,17 @@ internal abstract class ICLogicPinDef : ICPinDef, ILogicPinDef
         return base.GetZPriority() + (10f * (int)(Logic?.State ?? LogicState.Unreachable));
     }
 
-    private protected override string GetStatusText()
+    private protected override RunCollection GetStatusText()
     {
         if (State is PlacementState.Cleared)
         {
             return base.GetStatusText();
         }
 
-        return $"{base.GetStatusText()}, " + (Logic?.GetStatusTextFragment() ?? "unknown logic".L());
+        return [
+            .. base.GetStatusText(),
+            new Run(", "),
+            new Run(Logic?.GetStatusTextFragment() ?? "unknown logic".L())
+        ];
     }
 }

--- a/RandoMapCore/Pins/Defs/LogicInfo.cs
+++ b/RandoMapCore/Pins/Defs/LogicInfo.cs
@@ -1,3 +1,4 @@
+using MagicUI.Elements;
 using MapChanger;
 using RandomizerCore.Logic;
 
@@ -51,9 +52,12 @@ public class LogicInfo
         };
     }
 
-    internal string GetLogicText()
+    internal RunCollection GetLogicText()
     {
-        return $"{"Logic".L()}: {_logic.InfixSource}";
+        return [
+            new Run($"{"Logic".L()}: "),
+            new Run(_logic.InfixSource),
+        ];
     }
 }
 

--- a/RandoMapCore/Pins/Defs/PinDef.cs
+++ b/RandoMapCore/Pins/Defs/PinDef.cs
@@ -1,4 +1,5 @@
 using GlobalEnums;
+using MagicUI.Elements;
 using MapChanger;
 using MapChanger.Defs;
 using RandoMapCore.Modes;
@@ -23,7 +24,7 @@ internal abstract class PinDef
     internal IMapPosition MapPosition { get; init; }
     internal MapZone MapZone { get; init; } = MapZone.NONE;
 
-    private protected List<Func<string>> TextBuilders { get; } = [];
+    private protected List<Func<RunCollection>> TextBuilders { get; } = [];
 
     internal virtual void Update() { }
 
@@ -71,24 +72,31 @@ internal abstract class PinDef
         return RmcColors.GetColor(RmcColorSetting.Pin_Normal);
     }
 
-    public string GetText()
+    public RunCollection GetText()
     {
-        return string.Join("\n\n", TextBuilders.Select(tb => tb()).Where(t => t is not null));
+        return RunCollection.Join("\n\n", TextBuilders.Select(tb => tb()).Where(t => t is not null));
     }
 
-    private protected virtual string GetNameText()
+    private protected virtual RunCollection GetNameText()
     {
-        return Name.LC();
+        return [new Run(Name.LC())];
     }
 
-    private protected virtual string GetRoomText()
+    private protected virtual RunCollection GetRoomText()
     {
-        return $"{"Room".L()}: {SceneName?.LC() ?? "Unknown".L()}";
+        var sceneText = new Run(SceneName?.LC() ?? "Unknown".L());
+        return [
+            new Run($"{"Room".L()}: "),
+            sceneText,
+        ];
     }
 
-    private protected virtual string GetStatusText()
+    private protected virtual RunCollection GetStatusText()
     {
-        return $"{"Status".L()}: {"Unknown".L()}";
+        return [
+            new Run($"{"Status".L()}: "),
+            new Run("Unknown".L()),
+        ];
     }
 
     internal virtual float GetZPriority()

--- a/RandoMapCore/Pins/Defs/RandomizedBenchPinDef.cs
+++ b/RandoMapCore/Pins/Defs/RandomizedBenchPinDef.cs
@@ -1,4 +1,5 @@
 using ItemChanger;
+using MagicUI.Elements;
 using MapChanger;
 using RandoMapCore.Settings;
 using RandomizerCore.Logic;
@@ -90,8 +91,12 @@ internal sealed class RandomizedBenchPinDef : RandomizedPinDef
         return base.GetZPriority();
     }
 
-    private protected override string GetStatusText()
+    private protected override RunCollection GetStatusText()
     {
-        return $"{base.GetStatusText()}, {(Bench.IsVisitedBench ? "can warp" : "cannot warp").L()}";
+        return [
+            .. base.GetStatusText(),
+            new Run(", "),
+            new Run((Bench.IsVisitedBench ? "can warp" : "cannot warp").L())
+        ];
     }
 }

--- a/RandoMapCore/Pins/Defs/RandomizedPinDef.cs
+++ b/RandoMapCore/Pins/Defs/RandomizedPinDef.cs
@@ -9,12 +9,4 @@ internal class RandomizedPinDef(
     ProgressionManager pmNoSequenceBreak
 ) : ICLogicPinDef(placement, "Randomized", pm, pmNoSequenceBreak)
 {
-    private protected override string GetNeverObtainedText()
-    {
-        return base.GetNeverObtainedText()
-            ?.Replace("Pay ", "")
-            ?.Replace("Once you own ", "")
-            ?.Replace(", I'll gladly sell it to you.", "")
-            ?.Replace("Requires ", "");
-    }
 }

--- a/RandoMapCore/Pins/Defs/VanillaPinDef.cs
+++ b/RandoMapCore/Pins/Defs/VanillaPinDef.cs
@@ -1,4 +1,5 @@
 using ConnectionMetadataInjector.Util;
+using MagicUI.Elements;
 using MapChanger;
 using MapChanger.Defs;
 using RandoMapCore.Data;
@@ -129,28 +130,32 @@ internal sealed class VanillaPinDef : PinDef, ILogicPinDef
         return base.GetMixedPinShape();
     }
 
-    private protected override string GetStatusText()
+    private protected override RunCollection GetStatusText()
     {
-        var text = $"{"Status".L()}: {"Vanilla".L()}, ";
+        var statuses = new List<string>();
+        statuses.Add("Vanilla".L());
 
         if (Tracker.HasClearedLocation(Name))
         {
-            text += "cleared".L();
+            statuses.Add("cleared".L());
         }
         else
         {
             if (Persistent)
             {
-                text += "persistent".L();
+                statuses.Add("persistent".L());
             }
             else
             {
-                text += "not cleared".L();
+                statuses.Add("not cleared".L());
             }
 
-            text += ", " + (Logic?.GetStatusTextFragment() ?? "unknown logic".L());
+            statuses.Add(Logic?.GetStatusTextFragment() ?? "unknown logic".L());
         }
 
-        return text;
+        return [
+            new Run($"{"Status".L()}: "),
+            .. RunCollection.Join(", ", statuses.Select(s => new Run(s))),
+        ];
     }
 }

--- a/RandoMapCore/Pins/Objects/GridPin.cs
+++ b/RandoMapCore/Pins/Objects/GridPin.cs
@@ -1,10 +1,11 @@
-using System.Collections.ObjectModel;
+using MagicUI.Elements;
 using MapChanger;
 using MapChanger.Defs;
 using MapChanger.Map;
 using MapChanger.MonoBehaviours;
 using RandoMapCore.Input;
 using RandoMapCore.Rooms;
+using System.Collections.ObjectModel;
 
 namespace RandoMapCore.Pins;
 
@@ -88,13 +89,19 @@ internal class GridPin : RmcPin
         return true;
     }
 
-    public string GetText(bool lockSelection)
+    public RunCollection GetText(bool lockSelection)
     {
         if (HighlightScenes is null)
         {
             return GetText();
         }
 
-        return $"{GetText()}\n\n{"Press".L()} {LockGridPinInput.Instance.GetBindingsText()} {(lockSelection ? "to unlock pin selection" : "to lock pin selection and view highlighted rooms").L()}.";
+        return [
+            .. GetText(),
+            new Run("\n\n"),
+            new Run($"{"Press".L()} "),
+            new Run(LockGridPinInput.Instance.GetBindingsText()),
+            new Run($" {(lockSelection ? "to unlock pin selection" : "to lock pin selection and view highlighted rooms").L()}."),
+        ];
     }
 }

--- a/RandoMapCore/Pins/Objects/PinCluster.cs
+++ b/RandoMapCore/Pins/Objects/PinCluster.cs
@@ -1,3 +1,4 @@
+using MagicUI.Elements;
 using MapChanger;
 using RandoMapCore.Input;
 
@@ -41,7 +42,7 @@ internal class PinCluster(List<RmcPin> selectables) : SelectableGroup<RmcPin>(se
         }
     }
 
-    internal string GetText()
+    internal RunCollection GetText()
     {
         if (!_sortedPins.Any())
         {
@@ -57,6 +58,12 @@ internal class PinCluster(List<RmcPin> selectables) : SelectableGroup<RmcPin>(se
         var nextPin = _sortedPins[(_selectionIndex + 1) % _sortedPins.Length];
 
         var bindingsText = TogglePinClusterInput.Instance.GetBindingsText();
-        return $"{SelectedPin.GetText()}\n\n{"Press".L()} {bindingsText} {"to toggle selected pin to".L()} {nextPin.Name.LC()}.";
+        return [
+            .. SelectedPin.GetText(),
+            new Run("\n\n"),
+            new Run($"{"Press".L()} "),
+            new Run(bindingsText),
+            new Run($" {nextPin.Name.LC()}."),
+        ];
     }
 }

--- a/RandoMapCore/Pins/Objects/RmcPin.cs
+++ b/RandoMapCore/Pins/Objects/RmcPin.cs
@@ -1,6 +1,7 @@
-using System.Collections;
+using MagicUI.Elements;
 using MapChanger.MonoBehaviours;
 using RandoMapCore.Settings;
+using System.Collections;
 using UnityEngine;
 
 namespace RandoMapCore.Pins;
@@ -248,7 +249,7 @@ internal class RmcPin : BorderedBackgroundPin, ISelectable, IPeriodicUpdater
         }
     }
 
-    internal string GetText()
+    internal RunCollection GetText()
     {
         return Def.GetText();
     }

--- a/RandoMapCore/Pins/PlacementExtensions.cs
+++ b/RandoMapCore/Pins/PlacementExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using ItemChanger;
 using ItemChanger.Placements;
 using ItemChanger.Tags;
+using MagicUI.Elements;
 using MapChanger;
 
 namespace RandoMapCore.Pins;
@@ -62,19 +63,28 @@ internal static class PlacementExtensions
         return costs.Any() ? costs : null;
     }
 
-    internal static string ToText(this IEnumerable<AbstractItem> items, bool? nameOverride)
+    internal static RunCollection ToText(this IEnumerable<AbstractItem> items, bool? nameOverride)
     {
-        return string.Join(", ", items.Select(i => i.ToText(nameOverride)));
+        return RunCollection.Join("  -  ", items.Select(i => i.ToText(nameOverride)));
     }
 
-    internal static string ToTextWithCost(this IEnumerable<AbstractItem> items, bool? nameOverride, bool? costOverride)
+    internal static RunCollection ToTextWithCost(this IEnumerable<AbstractItem> items, bool? nameOverride, bool? costOverride)
     {
-        return string.Join(", ", items.Select(i => i.ToTextWithCosts(nameOverride, costOverride)));
+        return RunCollection.Join("  -  ", items.Select(i => i.ToTextWithCosts(nameOverride, costOverride)));
     }
 
-    internal static string ToCostText(this Cost cost, bool revealCost)
+    internal static RunCollection ToCostText(this Cost cost, bool revealCost)
     {
-        return $"{(revealCost ? cost.GetCostText() : "???")} {(cost.CanPay() ? "☑" : "☒")}";
+        string costText = cost.GetCostText()
+            ?.Replace("Pay ", "")
+            ?.Replace("Once you own ", "")
+            ?.Replace(", I'll gladly sell it to you.", "")
+            ?.Replace("Requires ", "");
+        return [
+            new Run(revealCost ? costText : "???"),
+            new Run(" "),
+            new Run(cost.CanPay() ? "☑" : "☒")
+        ];
     }
 
     internal static bool IsPersistent(this AbstractItem item)
@@ -87,23 +97,29 @@ internal static class PlacementExtensions
         return placement.Items.All(i => i.WasEverObtained());
     }
 
-    private static string ToText(this AbstractItem item, bool? showNameOverride)
+    private static Run ToText(this AbstractItem item, bool? showNameOverride)
     {
-        return (showNameOverride is true || (showNameOverride is null && item.CanPreviewName()))
+        string text = (showNameOverride is true || (showNameOverride is null && item.CanPreviewName()))
             ? item.GetPreviewName().LC()
             : "???";
+        return new Run(text);
     }
 
-    private static string ToTextWithCosts(this AbstractItem item, bool? showNameOverride, bool? showCostOverride)
+    private static RunCollection ToTextWithCosts(this AbstractItem item, bool? showNameOverride, bool? showCostOverride)
     {
+        var itemText = item.ToText(showNameOverride) with { Bold = true };
         if (item.GetTag<CostTag>()?.Cost?.GetInnerCosts() is not IEnumerable<Cost> costs)
         {
-            return item.ToText(showNameOverride);
+            return [itemText];
         }
 
         var showCost = showCostOverride is true || (showCostOverride is null && item.CanPreviewCost());
-        var costText = string.Join(", ", costs.Select(c => c.ToCostText(showCost)));
-        return $"{item.ToText(showNameOverride)} - {costText}";
+        var costText = RunCollection.Join(", ", costs.Select(c => c.ToCostText(showCost)));
+        return [
+            itemText,
+            new Run(": "),
+            .. costText,
+        ];
     }
 
     private static IEnumerable<Cost> GetInnerCosts(this Cost cost)

--- a/RandoMapCore/Pins/Selection/PinSelector.cs
+++ b/RandoMapCore/Pins/Selection/PinSelector.cs
@@ -1,4 +1,5 @@
-﻿using MapChanger;
+﻿using MagicUI.Elements;
+using MapChanger;
 using MapChanger.MonoBehaviours;
 using RandoMapCore.Modes;
 using RandoMapCore.UI;
@@ -66,7 +67,7 @@ internal class PinSelector : Selector
         RmcUIManager.WorldMap?.Update();
     }
 
-    internal string GetSelectionText()
+    internal RunCollection GetSelectionText()
     {
         return SelectedObject switch
         {

--- a/RandoMapCore/UI/Map/SelectionPanels/PinSelectionPanel.cs
+++ b/RandoMapCore/UI/Map/SelectionPanels/PinSelectionPanel.cs
@@ -39,10 +39,10 @@ internal class PinSelectionPanel : WorldMapPanel
     {
         base.Update();
 
-        if (RandoMapCoreMod.GS.PinSelectionOn && RmcPinManager.Selector?.GetSelectionText() is string text)
+        if (RandoMapCoreMod.GS.PinSelectionOn && RmcPinManager.Selector?.GetSelectionText() is RunCollection inlines)
         {
             Panel.Visibility = Visibility.Visible;
-            _text.Text = text;
+            _text.Inlines = inlines;
             _text.FontSize = (int)(20f * MapChangerMod.GS.UIScale);
             _text.MaxWidth = (int)(450f * MapChangerMod.GS.UIScale);
         }


### PR DESCRIPTION
This PR adds a number of improvements to formatting for item panels, largely targeted at making the preview list more readable when there are a large number of items/costs.

* Uses MagicUI 1.10's new rich text support to bold item names on IC pins.
* All other info panel content has migrated to the rich text API for consistency and to enable additional mixed formatting cases in the future.
* Adds more visual separation between each previewed item. Before, it was `Item 1 - Cost 1, Cost 2, Item 2 - Cost 1 ...`. Now it is `Item 1: Cost 1, Cost 2  -  Item 2: Cost 1 ...`.
* Moved the logic reducing verbosity of IC cost text from `RandomizedPinDef` to `PlacementExtensions.ToCostText` - I think it's reasonable that this applies to all IC pins regardless of randomized state.

![image](https://github.com/user-attachments/assets/518a2146-0f1a-41ae-b413-15b971af0efe)
